### PR TITLE
fix(android): annotation gestures and zoom-resilient positioning

### DIFF
--- a/flutter/android/gradle.properties
+++ b/flutter/android/gradle.properties
@@ -1,2 +1,8 @@
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
+
+# Build performance
+org.gradle.parallel=true
+org.gradle.caching=true
+org.gradle.configureondemand=true
+org.gradle.daemon=true

--- a/flutter/assets/html/osmd_template.html
+++ b/flutter/assets/html/osmd_template.html
@@ -117,7 +117,7 @@
         let currentStrokePoints = [];        // Points in the current stroke
         let annotationCanvases = new Map();  // pageIndex -> canvas element
         let storedAnnotations = new Map();   // pageIndex -> [{svgPath, measureNumber, x, y}, ...]
-        let strokeColor = '#FF0000';
+        let strokeColor = '#1A3A6B';
         let strokeWidth = 2.5;
 
         // ── Undo/Redo History Stack ───────────────────────────────────

--- a/flutter/assets/html/osmd_template.html
+++ b/flutter/assets/html/osmd_template.html
@@ -389,6 +389,7 @@
          * Get the bounding box of a measure in pixel coordinates
          * relative to its page div container.
          * Uses the DOM: .vf-measure elements with id matching the measure number.
+         * Adds padding to capture annotations drawn near measure edges.
          * Returns {x, y, w, h} or null if not found.
          */
         function getMeasureBBox(measureNumber, pageIndex) {
@@ -402,11 +403,15 @@
             const measureRect = measureEl.getBoundingClientRect();
             const pageRect = pageDiv.getBoundingClientRect();
 
+            // Expand bbox by 25% on each side so edge annotations stay in 0-1 range
+            const padX = measureRect.width * 0.25;
+            const padY = measureRect.height * 0.25;
+
             return {
-                x: measureRect.left - pageRect.left,
-                y: measureRect.top - pageRect.top,
-                w: measureRect.width,
-                h: measureRect.height,
+                x: (measureRect.left - pageRect.left) - padX,
+                y: (measureRect.top - pageRect.top) - padY,
+                w: measureRect.width + padX * 2,
+                h: measureRect.height + padY * 2,
             };
         }
 

--- a/flutter/assets/html/osmd_template.html
+++ b/flutter/assets/html/osmd_template.html
@@ -163,6 +163,14 @@
         /** Create annotation canvases for all rendered OSMD pages */
         function setupAnnotationCanvases() {
             const pages = document.querySelectorAll('div[id^="osmdCanvasPage"]');
+
+            // Purge stale canvas refs (DOM elements destroyed by OSMD re-render)
+            for (const [idx, canvas] of annotationCanvases) {
+                if (!canvas.parentElement || !document.contains(canvas)) {
+                    annotationCanvases.delete(idx);
+                }
+            }
+
             pages.forEach((pageDiv, index) => {
                 getOrCreateAnnotationCanvas(pageDiv, index);
             });

--- a/flutter/assets/html/osmd_template.html
+++ b/flutter/assets/html/osmd_template.html
@@ -463,13 +463,13 @@
                         // Measure-relative: look up current measure position and scale
                         const mBBox = getMeasureBBox(ann.measureNumber, pageIndex);
                         if (mBBox) {
-                            drawSvgPathMeasureRelative(ctx, ann.svgPath, ann.color || strokeColor, ann.width || strokeWidth, mBBox);
+                            drawSvgPathMeasureRelative(ctx, ann.svgPath, strokeColor, ann.width || strokeWidth, mBBox);
                         }
                     } else {
                         // Pixel coords: scale proportionally from original canvas size
                         const scaleX = ann.origWidth ? canvas.width / ann.origWidth : 1;
                         const scaleY = ann.origHeight ? canvas.height / ann.origHeight : 1;
-                        drawSvgPathScaled(ctx, ann.svgPath, ann.color || strokeColor, ann.width || strokeWidth, scaleX, scaleY);
+                        drawSvgPathScaled(ctx, ann.svgPath, strokeColor, ann.width || strokeWidth, scaleX, scaleY);
                     }
                 }
             }
@@ -543,8 +543,20 @@
                 if (!storedAnnotations.has(pi)) {
                     storedAnnotations.set(pi, []);
                 }
+                // Legacy annotations from DB lack coordSystem and origWidth/origHeight.
+                // Tag them so the proportional scaler can use current canvas size.
+                if (!ann.coordSystem) {
+                    const canvas = annotationCanvases.get(pi);
+                    ann.coordSystem = 'pixel';
+                    ann.origWidth = canvas ? canvas.width : null;
+                    ann.origHeight = canvas ? canvas.height : null;
+                }
                 storedAnnotations.get(pi).push(ann);
             }
+
+            // Convert loaded pixel annotations to measure-relative immediately
+            // so they survive future zoom/resize.
+            convertAnnotationsToMeasureRelative();
 
             // Redraw all pages
             for (const [pi] of storedAnnotations) {

--- a/flutter/assets/html/osmd_template.html
+++ b/flutter/assets/html/osmd_template.html
@@ -389,7 +389,6 @@
          * Get the bounding box of a measure in pixel coordinates
          * relative to its page div container.
          * Uses the DOM: .vf-measure elements with id matching the measure number.
-         * Adds padding to capture annotations drawn near measure edges.
          * Returns {x, y, w, h} or null if not found.
          */
         function getMeasureBBox(measureNumber, pageIndex) {
@@ -403,15 +402,11 @@
             const measureRect = measureEl.getBoundingClientRect();
             const pageRect = pageDiv.getBoundingClientRect();
 
-            // Expand bbox by 25% on each side so edge annotations stay in 0-1 range
-            const padX = measureRect.width * 0.25;
-            const padY = measureRect.height * 0.25;
-
             return {
-                x: (measureRect.left - pageRect.left) - padX,
-                y: (measureRect.top - pageRect.top) - padY,
-                w: measureRect.width + padX * 2,
-                h: measureRect.height + padY * 2,
+                x: measureRect.left - pageRect.left,
+                y: measureRect.top - pageRect.top,
+                w: measureRect.width,
+                h: measureRect.height,
             };
         }
 

--- a/flutter/assets/html/osmd_template.html
+++ b/flutter/assets/html/osmd_template.html
@@ -536,27 +536,15 @@
 
         /** Load annotations from Flutter (restore saved annotations) */
         function loadAnnotations(annotations) {
-            // annotations: [{pageIndex, svgPath, measureNumber, x, y, color, width}, ...]
+            // annotations: [{pageIndex, svgPath, measureNumber, x, y, color, width, coordSystem?}, ...]
             storedAnnotations.clear();
             for (const ann of annotations) {
                 const pi = ann.pageIndex || 0;
                 if (!storedAnnotations.has(pi)) {
                     storedAnnotations.set(pi, []);
                 }
-                // Legacy annotations from DB lack coordSystem and origWidth/origHeight.
-                // Tag them so the proportional scaler can use current canvas size.
-                if (!ann.coordSystem) {
-                    const canvas = annotationCanvases.get(pi);
-                    ann.coordSystem = 'pixel';
-                    ann.origWidth = canvas ? canvas.width : null;
-                    ann.origHeight = canvas ? canvas.height : null;
-                }
                 storedAnnotations.get(pi).push(ann);
             }
-
-            // Convert loaded pixel annotations to measure-relative immediately
-            // so they survive future zoom/resize.
-            convertAnnotationsToMeasureRelative();
 
             // Redraw all pages
             for (const [pi] of storedAnnotations) {

--- a/flutter/assets/html/osmd_template.html
+++ b/flutter/assets/html/osmd_template.html
@@ -181,6 +181,40 @@
             }
         }
 
+        /**
+         * Convert all annotations still in 'pixel' coord system to 'measure' coords.
+         * Called once when exiting drawing mode.
+         */
+        function convertAnnotationsToMeasureRelative() {
+            for (const [pageIndex, annotations] of storedAnnotations) {
+                for (const ann of annotations) {
+                    if (ann.coordSystem === 'measure') continue; // already converted
+
+                    const mBBox = getMeasureBBox(ann.measureNumber, pageIndex);
+                    if (!mBBox || mBBox.w <= 0 || mBBox.h <= 0) continue; // can't convert, leave as pixel
+
+                    // Parse the pixel-space SVG path
+                    const pixelPoints = svgPathToPoints(ann.svgPath);
+                    if (pixelPoints.length < 2) continue;
+
+                    // Convert each point to measure-relative (0-1 within measure bbox)
+                    const relPoints = pixelPoints.map(p => ({
+                        x: (p.x - mBBox.x) / mBBox.w,
+                        y: (p.y - mBBox.y) / mBBox.h,
+                    }));
+
+                    // Use higher precision for normalized coords
+                    ann.svgPath = pointsToSvgPathPrecise(relPoints);
+                    ann.coordSystem = 'measure';
+
+                    // Also update the midpoint x/y to measure-relative
+                    const mid = relPoints[Math.floor(relPoints.length / 2)];
+                    ann.x = mid.x;
+                    ann.y = mid.y;
+                }
+            }
+        }
+
         /** Toggle drawing mode on all annotation canvases */
         function setAnnotationMode(enabled) {
             annotationEnabled = enabled;
@@ -191,6 +225,13 @@
                     canvas.classList.remove('drawing-mode');
                 }
             }
+
+            // When exiting drawing mode, convert all pixel-space annotations
+            // to measure-relative coordinates for zoom/reflow resilience.
+            if (!enabled) {
+                convertAnnotationsToMeasureRelative();
+            }
+
             sendToFlutter('annotationModeChanged', { enabled: annotationEnabled });
         }
 
@@ -273,6 +314,10 @@
                 y: normY,
                 color: strokeColor,
                 width: strokeWidth,
+                // Starts as pixel coords; converted to measure-relative on exit drawing mode
+                coordSystem: 'pixel',
+                origWidth: canvas.width,
+                origHeight: canvas.height,
             };
 
             if (!storedAnnotations.has(pageIndex)) {
@@ -302,7 +347,7 @@
 
         // ── SVG Path Generation ───────────────────────────────────────
 
-        /** Convert an array of {x, y} points to an SVG path string */
+        /** Convert an array of {x, y} points to an SVG path string (pixel coords) */
         function pointsToSvgPath(points) {
             if (points.length === 0) return '';
             let path = `M ${points[0].x.toFixed(1)} ${points[0].y.toFixed(1)}`;
@@ -312,13 +357,25 @@
             return path;
         }
 
+        /**
+         * Like pointsToSvgPath but with higher decimal precision for normalized coords.
+         */
+        function pointsToSvgPathPrecise(points) {
+            if (points.length === 0) return '';
+            let path = `M ${points[0].x.toFixed(4)} ${points[0].y.toFixed(4)}`;
+            for (let i = 1; i < points.length; i++) {
+                path += ` L ${points[i].x.toFixed(4)} ${points[i].y.toFixed(4)}`;
+            }
+            return path;
+        }
+
         /** Parse an SVG path string back to an array of {x, y} points */
         function svgPathToPoints(svgPath) {
             const points = [];
-            const commands = svgPath.match(/[ML]\s*[\d.]+\s+[\d.]+/g);
+            const commands = svgPath.match(/[ML]\s*-?[\d.]+\s+-?[\d.]+/g);
             if (!commands) return points;
             for (const cmd of commands) {
-                const nums = cmd.match(/[\d.]+/g);
+                const nums = cmd.match(/-?[\d.]+/g);
                 if (nums && nums.length >= 2) {
                     points.push({ x: parseFloat(nums[0]), y: parseFloat(nums[1]) });
                 }
@@ -326,57 +383,56 @@
             return points;
         }
 
-        // ── Measure Coordinate Tracking ───────────────────────────────
+        // ── Measure Coordinate Tracking (DOM-based) ─────────────────────
 
-        /** Find the measure at a given point (pixel coordinates relative to page canvas) */
+        /**
+         * Get the bounding box of a measure in pixel coordinates
+         * relative to its page div container.
+         * Uses the DOM: .vf-measure elements with id matching the measure number.
+         * Returns {x, y, w, h} or null if not found.
+         */
+        function getMeasureBBox(measureNumber, pageIndex) {
+            const pageDiv = document.querySelectorAll('div[id^="osmdCanvasPage"]')[pageIndex];
+            if (!pageDiv) return null;
+
+            // OSMD renders .vf-measure elements with id = measure number
+            const measureEl = pageDiv.querySelector(`.vf-measure[id="${measureNumber}"]`);
+            if (!measureEl) return null;
+
+            const measureRect = measureEl.getBoundingClientRect();
+            const pageRect = pageDiv.getBoundingClientRect();
+
+            return {
+                x: measureRect.left - pageRect.left,
+                y: measureRect.top - pageRect.top,
+                w: measureRect.width,
+                h: measureRect.height,
+            };
+        }
+
+        /**
+         * Find which measure is closest to a point (in page-div-relative pixel coords).
+         */
         function findMeasureAtPoint(px, py, pageIndex) {
-            if (!osmd || !osmd.GraphicSheet || !osmd.GraphicSheet.musicPages) {
-                return { measureNumber: 1 };
-            }
-
-            const page = osmd.GraphicSheet.musicPages[pageIndex];
-            if (!page || !page.musicSystems) {
-                return { measureNumber: 1 };
-            }
-
-            // OSMD uses a 10 units-per-mm coordinate system
-            // Convert pixel coords to OSMD units for comparison
             const pageDiv = document.querySelectorAll('div[id^="osmdCanvasPage"]')[pageIndex];
             if (!pageDiv) return { measureNumber: 1 };
 
+            const measures = pageDiv.querySelectorAll('.vf-measure');
+            if (!measures.length) return { measureNumber: 1 };
+
+            const pageRect = pageDiv.getBoundingClientRect();
             let closestMeasure = 1;
             let closestDistance = Infinity;
 
-            for (const system of page.musicSystems) {
-                if (!system.graphicalMeasures) continue;
-                for (const measureArray of system.graphicalMeasures) {
-                    if (!measureArray || measureArray.length === 0) continue;
-                    const gm = measureArray[0];
-                    const bbox = gm.boundingBox;
-                    if (!bbox) continue;
+            for (const el of measures) {
+                const rect = el.getBoundingClientRect();
+                const cx = (rect.left + rect.width / 2) - pageRect.left;
+                const cy = (rect.top + rect.height / 2) - pageRect.top;
 
-                    // Get absolute position of the measure bounding box
-                    const absPos = bbox.absolutePosition;
-                    const size = bbox.size;
-                    if (!absPos || !size) continue;
-
-                    // Convert OSMD units to pixels (approximate)
-                    // OSMD uses 10 units per mm, screen is ~96 DPI = 3.78 px/mm
-                    const scale = (pageDiv.clientWidth / (page.pageWidth || pageDiv.clientWidth)) || 1;
-                    const mx = absPos.x * scale;
-                    const my = absPos.y * scale;
-                    const mw = size.width * scale;
-                    const mh = size.height * scale;
-
-                    // Center of measure
-                    const cx = mx + mw / 2;
-                    const cy = my + mh / 2;
-
-                    const dist = Math.sqrt((px - cx) ** 2 + (py - cy) ** 2);
-                    if (dist < closestDistance) {
-                        closestDistance = dist;
-                        closestMeasure = gm.parentSourceMeasure?.measureNumber || 1;
-                    }
+                const dist = Math.sqrt((px - cx) ** 2 + (py - cy) ** 2);
+                if (dist < closestDistance) {
+                    closestDistance = dist;
+                    closestMeasure = parseInt(el.id, 10) || 1;
                 }
             }
 
@@ -403,8 +459,18 @@
                     const py = ann.y * canvas.height;
                     STRUCTURED_SYMBOLS[ann.kind].render(ctx, px, py, ann.data || {});
                 } else if (ann.svgPath) {
-                    // Freehand annotation: draw SVG path
-                    drawSvgPath(ctx, ann.svgPath, ann.color || strokeColor, ann.width || strokeWidth);
+                    if (ann.coordSystem === 'measure') {
+                        // Measure-relative: look up current measure position and scale
+                        const mBBox = getMeasureBBox(ann.measureNumber, pageIndex);
+                        if (mBBox) {
+                            drawSvgPathMeasureRelative(ctx, ann.svgPath, ann.color || strokeColor, ann.width || strokeWidth, mBBox);
+                        }
+                    } else {
+                        // Pixel coords: scale proportionally from original canvas size
+                        const scaleX = ann.origWidth ? canvas.width / ann.origWidth : 1;
+                        const scaleY = ann.origHeight ? canvas.height / ann.origHeight : 1;
+                        drawSvgPathScaled(ctx, ann.svgPath, ann.color || strokeColor, ann.width || strokeWidth, scaleX, scaleY);
+                    }
                 }
             }
         }
@@ -418,6 +484,48 @@
             ctx.moveTo(points[0].x, points[0].y);
             for (let i = 1; i < points.length; i++) {
                 ctx.lineTo(points[i].x, points[i].y);
+            }
+            ctx.strokeStyle = color;
+            ctx.lineWidth = width;
+            ctx.lineCap = 'round';
+            ctx.lineJoin = 'round';
+            ctx.stroke();
+        }
+
+        /**
+         * Draw an SVG path with proportional scaling.
+         * Points in the path are in original pixel coordinates;
+         * scaleX/scaleY transform them to current canvas size.
+         */
+        function drawSvgPathScaled(ctx, svgPath, color, width, scaleX, scaleY) {
+            const points = svgPathToPoints(svgPath);
+            if (points.length < 2) return;
+
+            ctx.beginPath();
+            ctx.moveTo(points[0].x * scaleX, points[0].y * scaleY);
+            for (let i = 1; i < points.length; i++) {
+                ctx.lineTo(points[i].x * scaleX, points[i].y * scaleY);
+            }
+            ctx.strokeStyle = color;
+            ctx.lineWidth = width;
+            ctx.lineCap = 'round';
+            ctx.lineJoin = 'round';
+            ctx.stroke();
+        }
+
+        /**
+         * Draw an SVG path stored in measure-relative coordinates.
+         * Points are offsets within the measure bbox (0-1 range).
+         * Scaled to the measure's current pixel position.
+         */
+        function drawSvgPathMeasureRelative(ctx, svgPath, color, width, mBBox) {
+            const points = svgPathToPoints(svgPath);
+            if (points.length < 2) return;
+
+            ctx.beginPath();
+            ctx.moveTo(mBBox.x + points[0].x * mBBox.w, mBBox.y + points[0].y * mBBox.h);
+            for (let i = 1; i < points.length; i++) {
+                ctx.lineTo(mBBox.x + points[i].x * mBBox.w, mBBox.y + points[i].y * mBBox.h);
             }
             ctx.strokeStyle = color;
             ctx.lineWidth = width;

--- a/flutter/lib/screens/sheet_music_viewer_screen.dart
+++ b/flutter/lib/screens/sheet_music_viewer_screen.dart
@@ -203,8 +203,8 @@ class _SheetMusicViewerScreenState extends State<SheetMusicViewerScreen> {
             }
 
             return GestureDetector(
-              onTapUp: (details) => _handleTap(context, details),
-              onHorizontalDragEnd: (details) => _handleSwipe(details),
+              onTapUp: _annotationMode ? null : (details) => _handleTap(context, details),
+              onHorizontalDragEnd: _annotationMode ? null : (details) => _handleSwipe(details),
               child: Stack(
                 children: [
                   // Sheet music display
@@ -214,6 +214,7 @@ class _SheetMusicViewerScreenState extends State<SheetMusicViewerScreen> {
                       page: page,
                       songName: widget.appState.currentSong?.name ?? "",
                       appState: widget.appState,
+                      annotationMode: _annotationMode,
                       rendererKey: _rendererKey,
                       onHistoryChanged: (canUndo, canRedo) {
                         setState(() {
@@ -438,6 +439,7 @@ class _SheetMusicPage extends StatefulWidget {
   final String songName;
   final AppState appState;
   final GlobalKey? rendererKey;
+  final bool annotationMode;
   final OnHistoryChanged? onHistoryChanged;
   final OnAnnotationAdded? onAnnotationAdded;
   final OnAnnotationRemoved? onAnnotationRemoved;
@@ -450,6 +452,7 @@ class _SheetMusicPage extends StatefulWidget {
     required this.songName,
     required this.appState,
     this.rendererKey,
+    this.annotationMode = false,
     this.onHistoryChanged,
     this.onAnnotationAdded,
     this.onAnnotationRemoved,
@@ -624,6 +627,7 @@ class _SheetMusicPageState extends State<_SheetMusicPage> {
           ValueKey('musicxml-${widget.page.path}-$orientation'),
       musicXml: _musicXmlContent!,
       backgroundColor: Colors.white,
+      annotationMode: widget.annotationMode,
       options: MusicXmlRenderOptions(
         initialPage: widget.page.internalPageNumber,
         currentPage: widget.page.internalPageNumber,

--- a/flutter/lib/screens/sheet_music_viewer_screen.dart
+++ b/flutter/lib/screens/sheet_music_viewer_screen.dart
@@ -173,6 +173,9 @@ class _SheetMusicViewerScreenState extends State<SheetMusicViewerScreen> {
               icon: const Icon(Icons.zoom_out),
               onPressed: (_annotationMode || _isRendering) ? null : () {
                 setState(() { _isRendering = true; });
+                Future.delayed(const Duration(seconds: 3), () {
+                  if (mounted && _isRendering) setState(() { _isRendering = false; });
+                });
                 widget.appState.zoom =
                     (widget.appState.zoom - 0.1).clamp(0.5, 3.0);
               },
@@ -182,6 +185,9 @@ class _SheetMusicViewerScreenState extends State<SheetMusicViewerScreen> {
               icon: const Icon(Icons.zoom_in),
               onPressed: (_annotationMode || _isRendering) ? null : () {
                 setState(() { _isRendering = true; });
+                Future.delayed(const Duration(seconds: 3), () {
+                  if (mounted && _isRendering) setState(() { _isRendering = false; });
+                });
                 widget.appState.zoom =
                     (widget.appState.zoom + 0.1).clamp(0.5, 3.0);
               },
@@ -240,11 +246,6 @@ class _SheetMusicViewerScreenState extends State<SheetMusicViewerScreen> {
                       onAnnotationRemoved: _handleAnnotationRemoved,
                       onAnnotationsCleared: _handleAnnotationsCleared,
                       onScoreLoaded: _loadSavedAnnotations,
-                      onRenderComplete: () {
-                        if (_isRendering) {
-                          setState(() { _isRendering = false; });
-                        }
-                      },
                     ),
                   ),
                   // Navigation overlay
@@ -464,7 +465,6 @@ class _SheetMusicPage extends StatefulWidget {
   final OnAnnotationRemoved? onAnnotationRemoved;
   final OnAnnotationsCleared? onAnnotationsCleared;
   final VoidCallback? onScoreLoaded;
-  final VoidCallback? onRenderComplete;
 
   const _SheetMusicPage({
     super.key,
@@ -478,7 +478,6 @@ class _SheetMusicPage extends StatefulWidget {
     this.onAnnotationRemoved,
     this.onAnnotationsCleared,
     this.onScoreLoaded,
-    this.onRenderComplete,
   });
 
   @override
@@ -670,7 +669,6 @@ class _SheetMusicPageState extends State<_SheetMusicPage> {
 
         // Load saved annotations after score is rendered
         widget.onScoreLoaded?.call();
-        widget.onRenderComplete?.call();
       },
       onError: (message, type) {
         debugPrint('MusicXML render error ($type): $message');

--- a/flutter/lib/screens/sheet_music_viewer_screen.dart
+++ b/flutter/lib/screens/sheet_music_viewer_screen.dart
@@ -131,6 +131,11 @@ class _SheetMusicViewerScreenState extends State<SheetMusicViewerScreen> {
                     : null,
                 tooltip: 'Redo',
               ),
+              IconButton(
+                icon: const Icon(Icons.delete_outline),
+                onPressed: () => (_rendererKey.currentState as dynamic)?.clearAnnotations(),
+                tooltip: 'Clear All Annotations',
+              ),
               const VerticalDivider(width: 1, color: Colors.white24),
               // Export/import only on native (requires file system)
               if (!kIsWeb) ...[

--- a/flutter/lib/screens/sheet_music_viewer_screen.dart
+++ b/flutter/lib/screens/sheet_music_viewer_screen.dart
@@ -163,13 +163,13 @@ class _SheetMusicViewerScreenState extends State<SheetMusicViewerScreen> {
             const VerticalDivider(width: 1, color: Colors.white24),
             IconButton(
               icon: const Icon(Icons.zoom_out),
-              onPressed: () => widget.appState.zoom =
+              onPressed: _annotationMode ? null : () => widget.appState.zoom =
                   (widget.appState.zoom - 0.1).clamp(0.5, 3.0),
               tooltip: 'Zoom Out',
             ),
             IconButton(
               icon: const Icon(Icons.zoom_in),
-              onPressed: () => widget.appState.zoom =
+              onPressed: _annotationMode ? null : () => widget.appState.zoom =
                   (widget.appState.zoom + 0.1).clamp(0.5, 3.0),
               tooltip: 'Zoom In',
             ),

--- a/flutter/lib/screens/sheet_music_viewer_screen.dart
+++ b/flutter/lib/screens/sheet_music_viewer_screen.dart
@@ -324,7 +324,7 @@ class _SheetMusicViewerScreenState extends State<SheetMusicViewerScreen> {
       'measureNumber': ann.measureNumber,
       'x': ann.x,
       'y': ann.y,
-      'color': '#FF0000',
+      'color': '#1A3A6B',
       'width': 2.5,
     }).toList();
 
@@ -389,7 +389,7 @@ class _SheetMusicViewerScreenState extends State<SheetMusicViewerScreen> {
         'measureNumber': ann.measureNumber,
         'x': ann.x,
         'y': ann.y,
-        'color': '#FF0000',
+        'color': '#1A3A6B',
         'width': 2.5,
       }).toList();
       (_rendererKey.currentState as dynamic)?.loadAnnotations(annotationMaps);

--- a/flutter/lib/screens/sheet_music_viewer_screen.dart
+++ b/flutter/lib/screens/sheet_music_viewer_screen.dart
@@ -29,6 +29,7 @@ class _SheetMusicViewerScreenState extends State<SheetMusicViewerScreen> {
   bool _annotationMode = false;
   bool _canUndo = false;
   bool _canRedo = false;
+  bool _isRendering = false;
   final GlobalKey _rendererKey = GlobalKey();
 
   // Annotation persistence
@@ -91,11 +92,13 @@ class _SheetMusicViewerScreenState extends State<SheetMusicViewerScreen> {
         widget.appState.goToPage(0);
       } else if (event.logicalKey == LogicalKeyboardKey.end) {
         widget.appState.goToPage(widget.appState.totalPages - 1);
-      } else if (event.logicalKey == LogicalKeyboardKey.equal ||
-          event.logicalKey == LogicalKeyboardKey.add) {
+      } else if (!_isRendering && (event.logicalKey == LogicalKeyboardKey.equal ||
+          event.logicalKey == LogicalKeyboardKey.add)) {
+        setState(() { _isRendering = true; });
         widget.appState.zoom = (widget.appState.zoom + 0.1).clamp(0.5, 3.0);
-      } else if (event.logicalKey == LogicalKeyboardKey.minus ||
-          event.logicalKey == LogicalKeyboardKey.underscore) {
+      } else if (!_isRendering && (event.logicalKey == LogicalKeyboardKey.minus ||
+          event.logicalKey == LogicalKeyboardKey.underscore)) {
+        setState(() { _isRendering = true; });
         widget.appState.zoom = (widget.appState.zoom - 0.1).clamp(0.5, 3.0);
       } else if (event.logicalKey == LogicalKeyboardKey.escape) {
         Navigator.of(context).pop();
@@ -168,14 +171,20 @@ class _SheetMusicViewerScreenState extends State<SheetMusicViewerScreen> {
             const VerticalDivider(width: 1, color: Colors.white24),
             IconButton(
               icon: const Icon(Icons.zoom_out),
-              onPressed: _annotationMode ? null : () => widget.appState.zoom =
-                  (widget.appState.zoom - 0.1).clamp(0.5, 3.0),
+              onPressed: (_annotationMode || _isRendering) ? null : () {
+                setState(() { _isRendering = true; });
+                widget.appState.zoom =
+                    (widget.appState.zoom - 0.1).clamp(0.5, 3.0);
+              },
               tooltip: 'Zoom Out',
             ),
             IconButton(
               icon: const Icon(Icons.zoom_in),
-              onPressed: _annotationMode ? null : () => widget.appState.zoom =
-                  (widget.appState.zoom + 0.1).clamp(0.5, 3.0),
+              onPressed: (_annotationMode || _isRendering) ? null : () {
+                setState(() { _isRendering = true; });
+                widget.appState.zoom =
+                    (widget.appState.zoom + 0.1).clamp(0.5, 3.0);
+              },
               tooltip: 'Zoom In',
             ),
             ListenableBuilder(
@@ -231,6 +240,11 @@ class _SheetMusicViewerScreenState extends State<SheetMusicViewerScreen> {
                       onAnnotationRemoved: _handleAnnotationRemoved,
                       onAnnotationsCleared: _handleAnnotationsCleared,
                       onScoreLoaded: _loadSavedAnnotations,
+                      onRenderComplete: () {
+                        if (_isRendering) {
+                          setState(() { _isRendering = false; });
+                        }
+                      },
                     ),
                   ),
                   // Navigation overlay
@@ -450,6 +464,7 @@ class _SheetMusicPage extends StatefulWidget {
   final OnAnnotationRemoved? onAnnotationRemoved;
   final OnAnnotationsCleared? onAnnotationsCleared;
   final VoidCallback? onScoreLoaded;
+  final VoidCallback? onRenderComplete;
 
   const _SheetMusicPage({
     super.key,
@@ -463,6 +478,7 @@ class _SheetMusicPage extends StatefulWidget {
     this.onAnnotationRemoved,
     this.onAnnotationsCleared,
     this.onScoreLoaded,
+    this.onRenderComplete,
   });
 
   @override
@@ -654,6 +670,7 @@ class _SheetMusicPageState extends State<_SheetMusicPage> {
 
         // Load saved annotations after score is rendered
         widget.onScoreLoaded?.call();
+        widget.onRenderComplete?.call();
       },
       onError: (message, type) {
         debugPrint('MusicXML render error ($type): $message');

--- a/flutter/lib/widgets/musicxml_platform_renderer_native.dart
+++ b/flutter/lib/widgets/musicxml_platform_renderer_native.dart
@@ -24,6 +24,7 @@ Widget buildMusicXmlRenderer({
   OnAnnotationsCleared? onAnnotationsCleared,
   OnAnnotationModeChanged? onAnnotationModeChanged,
   OnHistoryChanged? onHistoryChanged,
+  bool annotationMode = false,
 }) {
   return MusicXmlWebRenderer(
     key: key,
@@ -39,5 +40,6 @@ Widget buildMusicXmlRenderer({
     onAnnotationsCleared: onAnnotationsCleared,
     onAnnotationModeChanged: onAnnotationModeChanged,
     onHistoryChanged: onHistoryChanged,
+    annotationMode: annotationMode,
   );
 }

--- a/flutter/lib/widgets/musicxml_platform_renderer_web.dart
+++ b/flutter/lib/widgets/musicxml_platform_renderer_web.dart
@@ -25,6 +25,7 @@ Widget buildMusicXmlRenderer({
   OnAnnotationsCleared? onAnnotationsCleared,
   OnAnnotationModeChanged? onAnnotationModeChanged,
   OnHistoryChanged? onHistoryChanged,
+  bool annotationMode = false,
 }) {
   return MusicXmlWebRendererHtml(
     key: key,

--- a/flutter/lib/widgets/musicxml_web_renderer.dart
+++ b/flutter/lib/widgets/musicxml_web_renderer.dart
@@ -90,6 +90,7 @@ class MusicXmlWebRendererState extends State<MusicXmlWebRenderer> {
   WebViewController? _controller;
   bool _isReady = false;
   bool _isLoading = true;
+  bool _isZoomReload = false;
   String? _error;
   String? _htmlContent;
 
@@ -361,6 +362,14 @@ class MusicXmlWebRendererState extends State<MusicXmlWebRenderer> {
       _loadCompleter!.complete();
     }
 
+    // Skip annotation reload on zoom — JS already has measure-relative
+    // annotations in storedAnnotations that survive re-render.
+    if (_isZoomReload) {
+      _isZoomReload = false;
+      debugPrint('=== TRACE: _handleScoreLoaded END (zoom reload, skipping onLoaded)');
+      return;
+    }
+
     // Report to parent - just pass through the info from OSMD
     debugPrint(
       '=== TRACE: Calling widget.onLoaded callback (pageCount=${info.pageCount})',
@@ -385,7 +394,9 @@ class MusicXmlWebRendererState extends State<MusicXmlWebRenderer> {
     // Update zoom level in JavaScript
     _controller?.runJavaScript('zoomLevel = $zoom;');
 
-    // Reload the FULL document at new zoom
+    // Reload the FULL document at new zoom — but skip annotation reload
+    // since JS already has measure-relative annotations in memory.
+    _isZoomReload = true;
     setState(() {
       _isLoading = true;
     });

--- a/flutter/lib/widgets/musicxml_web_renderer.dart
+++ b/flutter/lib/widgets/musicxml_web_renderer.dart
@@ -367,15 +367,14 @@ class MusicXmlWebRendererState extends State<MusicXmlWebRenderer> {
     if (_isZoomReload) {
       _isZoomReload = false;
       debugPrint('=== TRACE: _handleScoreLoaded END (zoom reload, skipping onLoaded)');
-      return;
+    } else {
+      // Report to parent - just pass through the info from OSMD
+      debugPrint(
+        '=== TRACE: Calling widget.onLoaded callback (pageCount=${info.pageCount})',
+      );
+      widget.onLoaded?.call(info);
+      debugPrint('=== TRACE: _handleScoreLoaded END');
     }
-
-    // Report to parent - just pass through the info from OSMD
-    debugPrint(
-      '=== TRACE: Calling widget.onLoaded callback (pageCount=${info.pageCount})',
-    );
-    widget.onLoaded?.call(info);
-    debugPrint('=== TRACE: _handleScoreLoaded END');
   }
 
   /// Set the current page in a paginated view.

--- a/flutter/lib/widgets/musicxml_web_renderer.dart
+++ b/flutter/lib/widgets/musicxml_web_renderer.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:webview_flutter/webview_flutter.dart';
@@ -58,6 +59,9 @@ class MusicXmlWebRenderer extends StatefulWidget {
   /// Called when undo/redo history state changes.
   final OnHistoryChanged? onHistoryChanged;
 
+  /// Whether annotation mode is active (enables WebView gesture claiming on Android).
+  final bool annotationMode;
+
   const MusicXmlWebRenderer({
     super.key,
     this.musicXml,
@@ -72,6 +76,7 @@ class MusicXmlWebRenderer extends StatefulWidget {
     this.onAnnotationsCleared,
     this.onAnnotationModeChanged,
     this.onHistoryChanged,
+    this.annotationMode = false,
   }) : assert(
          musicXml != null || musicXmlUrl != null,
          'Either musicXml or musicXmlUrl must be provided',
@@ -479,7 +484,22 @@ class MusicXmlWebRendererState extends State<MusicXmlWebRenderer> {
 
     return Stack(
       children: [
-        WebViewWidget(controller: _controller!),
+        WebViewWidget(
+          controller: _controller!,
+          gestureRecognizers: widget.annotationMode
+              ? <Factory<OneSequenceGestureRecognizer>>{
+                  Factory<VerticalDragGestureRecognizer>(
+                    () => VerticalDragGestureRecognizer(),
+                  ),
+                  Factory<HorizontalDragGestureRecognizer>(
+                    () => HorizontalDragGestureRecognizer(),
+                  ),
+                  Factory<LongPressGestureRecognizer>(
+                    () => LongPressGestureRecognizer(),
+                  ),
+                }
+              : <Factory<OneSequenceGestureRecognizer>>{},
+        ),
         if (_isLoading) _buildLoading(),
         if (_error != null) _buildError(),
       ],

--- a/flutter/test/screens/sheet_music_viewer_gesture_test.dart
+++ b/flutter/test/screens/sheet_music_viewer_gesture_test.dart
@@ -1,0 +1,127 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:borge/screens/sheet_music_viewer_screen.dart';
+import 'package:borge/state/app_state.dart';
+import 'package:borge/models/models.dart' as models;
+
+void main() {
+  group('SheetMusicViewerScreen Gesture Handling', () {
+    late AppState appState;
+    late models.Song testSong;
+
+    setUp(() {
+      appState = AppState();
+      
+      // Create a test song with a MusicXML page
+      final testPage = models.Page(
+        path: '/test/song.musicxml',
+        pageNumber: 1,
+        extension: '.musicxml',
+      );
+      testSong = models.Song(
+        id: 'test-song',
+        name: 'Test Song',
+        pages: [testPage],
+      );
+      
+      // Select the song in AppState
+      appState.selectSong(testSong);
+    });
+
+    testWidgets('GestureDetector has active handlers in default mode', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: SheetMusicViewerScreen(appState: appState),
+        ),
+      );
+
+      // Find the GestureDetector that wraps the Stack (the main one for navigation)
+      final gestureDetectors = find.byType(GestureDetector);
+      expect(gestureDetectors, findsWidgets);
+      
+      // Find the one with Stack as child
+      final gestureDetector = tester.widgetList<GestureDetector>(gestureDetectors)
+          .firstWhere((gd) => gd.child is Stack);
+
+      // Verify handlers are not null in default mode
+      expect(gestureDetector.onTapUp, isNotNull);
+      expect(gestureDetector.onHorizontalDragEnd, isNotNull);
+    });
+
+    testWidgets('GestureDetector handlers become null in annotation mode', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: SheetMusicViewerScreen(appState: appState),
+        ),
+      );
+
+      // Verify initial state - find the GestureDetector that wraps Stack
+      var gestureDetectors = find.byType(GestureDetector);
+      var gestureDetector = tester.widgetList<GestureDetector>(gestureDetectors)
+          .firstWhere((gd) => gd.child is Stack);
+      expect(gestureDetector.onTapUp, isNotNull);
+      expect(gestureDetector.onHorizontalDragEnd, isNotNull);
+
+      // Find and tap the draw button (Icons.draw_outlined when off)
+      final drawButton = find.byIcon(Icons.draw_outlined);
+      expect(drawButton, findsOneWidget);
+      await tester.tap(drawButton);
+      await tester.pump();
+
+      // Find the GestureDetector again after state change
+      gestureDetectors = find.byType(GestureDetector);
+      gestureDetector = tester.widgetList<GestureDetector>(gestureDetectors)
+          .firstWhere((gd) => gd.child is Stack);
+
+      // Verify handlers are now null
+      expect(gestureDetector.onTapUp, isNull);
+      expect(gestureDetector.onHorizontalDragEnd, isNull);
+
+      // Verify the icon changed to Icons.draw (on state)
+      expect(find.byIcon(Icons.draw), findsOneWidget);
+      expect(find.byIcon(Icons.draw_outlined), findsNothing);
+    });
+
+    testWidgets('GestureDetector handlers are restored when annotation mode is toggled off', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: SheetMusicViewerScreen(appState: appState),
+        ),
+      );
+
+      // Turn annotation mode ON
+      await tester.tap(find.byIcon(Icons.draw_outlined));
+      await tester.pump();
+
+      // Verify handlers are null
+      var gestureDetectors = find.byType(GestureDetector);
+      var gestureDetector = tester.widgetList<GestureDetector>(gestureDetectors)
+          .firstWhere((gd) => gd.child is Stack);
+      expect(gestureDetector.onTapUp, isNull);
+      expect(gestureDetector.onHorizontalDragEnd, isNull);
+
+      // Turn annotation mode OFF
+      await tester.tap(find.byIcon(Icons.draw));
+      await tester.pump();
+
+      // Find the GestureDetector again
+      gestureDetectors = find.byType(GestureDetector);
+      gestureDetector = tester.widgetList<GestureDetector>(gestureDetectors)
+          .firstWhere((gd) => gd.child is Stack);
+
+      // Verify handlers are restored
+      expect(gestureDetector.onTapUp, isNotNull);
+      expect(gestureDetector.onHorizontalDragEnd, isNotNull);
+
+      // Verify icon is back to outlined
+      expect(find.byIcon(Icons.draw_outlined), findsOneWidget);
+      expect(find.byIcon(Icons.draw), findsNothing);
+    });
+  });
+}

--- a/flutter/web/osmd_frame.html
+++ b/flutter/web/osmd_frame.html
@@ -474,13 +474,13 @@
                         // Measure-relative: look up current measure position and scale
                         const mBBox = getMeasureBBox(ann.measureNumber, pageIndex);
                         if (mBBox) {
-                            drawSvgPathMeasureRelative(ctx, ann.svgPath, ann.color || strokeColor, ann.width || strokeWidth, mBBox);
+                            drawSvgPathMeasureRelative(ctx, ann.svgPath, strokeColor, ann.width || strokeWidth, mBBox);
                         }
                     } else {
                         // Pixel coords: scale proportionally from original canvas size
                         const scaleX = ann.origWidth ? canvas.width / ann.origWidth : 1;
                         const scaleY = ann.origHeight ? canvas.height / ann.origHeight : 1;
-                        drawSvgPathScaled(ctx, ann.svgPath, ann.color || strokeColor, ann.width || strokeWidth, scaleX, scaleY);
+                        drawSvgPathScaled(ctx, ann.svgPath, strokeColor, ann.width || strokeWidth, scaleX, scaleY);
                     }
                 }
             }
@@ -535,8 +535,20 @@
                 if (!storedAnnotations.has(pi)) {
                     storedAnnotations.set(pi, []);
                 }
+                // Legacy annotations from DB lack coordSystem and origWidth/origHeight.
+                // Tag them so the proportional scaler can use current canvas size.
+                if (!ann.coordSystem) {
+                    const canvas = annotationCanvases.get(pi);
+                    ann.coordSystem = 'pixel';
+                    ann.origWidth = canvas ? canvas.width : null;
+                    ann.origHeight = canvas ? canvas.height : null;
+                }
                 storedAnnotations.get(pi).push(ann);
             }
+
+            // Convert loaded pixel annotations to measure-relative immediately
+            // so they survive future zoom/resize.
+            convertAnnotationsToMeasureRelative();
 
             for (const [pi] of storedAnnotations) {
                 redrawAnnotations(pi);

--- a/flutter/web/osmd_frame.html
+++ b/flutter/web/osmd_frame.html
@@ -401,7 +401,6 @@
          * Get the bounding box of a measure in pixel coordinates
          * relative to its page div container.
          * Uses the DOM: .vf-measure elements with id matching the measure number.
-         * Adds padding to capture annotations drawn near measure edges.
          * Returns {x, y, w, h} or null if not found.
          */
         function getMeasureBBox(measureNumber, pageIndex) {
@@ -415,15 +414,11 @@
             const measureRect = measureEl.getBoundingClientRect();
             const pageRect = pageDiv.getBoundingClientRect();
 
-            // Expand bbox by 25% on each side so edge annotations stay in 0-1 range
-            const padX = measureRect.width * 0.25;
-            const padY = measureRect.height * 0.25;
-
             return {
-                x: (measureRect.left - pageRect.left) - padX,
-                y: (measureRect.top - pageRect.top) - padY,
-                w: measureRect.width + padX * 2,
-                h: measureRect.height + padY * 2,
+                x: measureRect.left - pageRect.left,
+                y: measureRect.top - pageRect.top,
+                w: measureRect.width,
+                h: measureRect.height,
             };
         }
 

--- a/flutter/web/osmd_frame.html
+++ b/flutter/web/osmd_frame.html
@@ -535,20 +535,8 @@
                 if (!storedAnnotations.has(pi)) {
                     storedAnnotations.set(pi, []);
                 }
-                // Legacy annotations from DB lack coordSystem and origWidth/origHeight.
-                // Tag them so the proportional scaler can use current canvas size.
-                if (!ann.coordSystem) {
-                    const canvas = annotationCanvases.get(pi);
-                    ann.coordSystem = 'pixel';
-                    ann.origWidth = canvas ? canvas.width : null;
-                    ann.origHeight = canvas ? canvas.height : null;
-                }
                 storedAnnotations.get(pi).push(ann);
             }
-
-            // Convert loaded pixel annotations to measure-relative immediately
-            // so they survive future zoom/resize.
-            convertAnnotationsToMeasureRelative();
 
             for (const [pi] of storedAnnotations) {
                 redrawAnnotations(pi);

--- a/flutter/web/osmd_frame.html
+++ b/flutter/web/osmd_frame.html
@@ -151,7 +151,7 @@
         let currentStrokePoints = [];
         let annotationCanvases = new Map();
         let storedAnnotations = new Map();
-        let strokeColor = '#FF0000';
+        let strokeColor = '#1A3A6B';
         let strokeWidth = 2.5;
 
         // ── Undo/Redo History Stack ───────────────────────────────────

--- a/flutter/web/osmd_frame.html
+++ b/flutter/web/osmd_frame.html
@@ -401,6 +401,7 @@
          * Get the bounding box of a measure in pixel coordinates
          * relative to its page div container.
          * Uses the DOM: .vf-measure elements with id matching the measure number.
+         * Adds padding to capture annotations drawn near measure edges.
          * Returns {x, y, w, h} or null if not found.
          */
         function getMeasureBBox(measureNumber, pageIndex) {
@@ -414,11 +415,15 @@
             const measureRect = measureEl.getBoundingClientRect();
             const pageRect = pageDiv.getBoundingClientRect();
 
+            // Expand bbox by 25% on each side so edge annotations stay in 0-1 range
+            const padX = measureRect.width * 0.25;
+            const padY = measureRect.height * 0.25;
+
             return {
-                x: measureRect.left - pageRect.left,
-                y: measureRect.top - pageRect.top,
-                w: measureRect.width,
-                h: measureRect.height,
+                x: (measureRect.left - pageRect.left) - padX,
+                y: (measureRect.top - pageRect.top) - padY,
+                w: measureRect.width + padX * 2,
+                h: measureRect.height + padY * 2,
             };
         }
 


### PR DESCRIPTION
## Summary

- **Disable navigation gestures in annotation mode** so drawing works without conflicting with scroll/zoom
- **Anchor annotations to measure bounding boxes** using DOM-based `.vf-measure` element lookup (ported from web approach), making annotations survive zoom in/out
- **Prevent zoom during annotation drawing** and gate zoom buttons with a render-complete timer to avoid race conditions
- **Add clear-all annotations button** (trash icon) in drawing mode toolbar
- **Change annotation color to dark blue** (`#1A3A6B`) on both web and native
- **Purge stale canvas refs** after OSMD re-renders to prevent drawing on detached DOM elements
- **Skip DB reload on zoom** to preserve in-memory measure-relative annotations

## Key Design Decisions

- Annotations stored as pixel coords during drawing, converted to measure-relative (0–1 within `.vf-measure` bbox) on exiting drawing mode
- On redraw, `getMeasureBBox()` queries current DOM position and maps back to pixels
- `_isRendering` flag with 3-second `Future.delayed` fallback re-enables zoom buttons (simpler than plumbing `onRenderComplete` through widget layers)
- Old DB annotations without `coordSystem` field render with pixel fallback (accepted tradeoff — only new annotations are zoom-resilient)

## Follow-up

- `borge-98b`: Unify annotation JS between web (`osmd_frame.html`) and native (`osmd_template.html`)

## Testing

- 78/78 Flutter widget tests pass
- Manual testing on Android confirmed: annotations scale with zoom, zoom buttons re-enable, clear-all works